### PR TITLE
Corrige tamaño grilla en pantallas de distintos tamaños

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -101,5 +101,26 @@
         {% endfor %}
     </div>
 </div>
+<script>
+    function setGridSize() {
+        var windowWidth = window.innerWidth;
+        var windowHeight = window.innerHeight;
+
+        var maxColWidth = windowWidth / {{ page.width }};
+        var maxRowHeight = windowHeight / {{ page.height }};
+
+        var optimalSquareSize = Math.min(maxColWidth, maxRowHeight);
+
+        console.log(optimalSquareSize);
+
+        var elements = document.getElementsByClassName("page");
+        for (var i = 0; i < elements.length; i++) {
+            elements[i].style.gridTemplateColumns = "repeat({{ page.width }}, minmax(0, " + optimalSquareSize + "px))";
+            elements[i].style.gridTemplateRows = "repeat({{ page.height }}, minmax(0, " + optimalSquareSize + "px))";
+        }
+    };
+    setGridSize();
+    window.addEventListener('resize', setGridSize);
+</script>
 
 </body>


### PR DESCRIPTION
Para una grilla simple: 
- de tamaño 4x4, 
- con los cuatro vertices pintados de azul 
- y los 4 cuadrados del centro de rojo

Antes de este PR se veía de la siguiente manera para distintos tamaños de pantalla:

https://github.com/fisadev/simpyt/assets/1953767/3178194a-85f1-4018-871c-ff24c23a0d26

Con los cambios de este PR se ve de la siguiente manera:

https://github.com/fisadev/simpyt/assets/1953767/f57f3e18-c3c7-4560-9afc-e51744ca76bb

